### PR TITLE
[nemo-qml-plugin-devicelock] Provide an authentication service on the system bus. Contributes to JB#55160

### DIFF
--- a/src/nemo-devicelock/host/hostauthenticator.h
+++ b/src/nemo-devicelock/host/hostauthenticator.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2016 Jolla Ltd
- * Contact: Andrew den Exter <andrew.den.exter@jolla.com>
+ * Copyright (c) 2016 - 2021 Jolla Ltd
+ * Copyright (c) 2021 Open Mobile Platform LLC
  *
  * You may use this file under the terms of the BSD license as follows:
  *
@@ -223,6 +223,7 @@ private:
         QVariant challengeCode;
         QVariantMap properties;
         QString connection;
+        QString address;
         QString client;
         QString message;
         uint pid = 0;

--- a/src/nemo-devicelock/host/hostobject.cpp
+++ b/src/nemo-devicelock/host/hostobject.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2016 Jolla Ltd
- * Contact: Andrew den Exter <andrew.den.exter@jolla.com>
+ * Copyright (c) 2016 - 2021 Jolla Ltd
+ * Copyright (c) 2021 Open Mobile Platform LLC
  *
  * You may use this file under the terms of the BSD license as follows:
  *
@@ -88,6 +88,17 @@ void HostObject::clientDisconnected(const QString &connectionName)
 
     if (m_activeConnection == connectionName) {
         m_activeConnection.clear();
+        m_activeAddress.clear();
+        m_activeClient.clear();
+        cancel();
+    }
+}
+
+void HostObject::nameLost(const QString &name)
+{
+    if (m_activeAddress == name && m_activeConnection == systemBus().connection().name()) {
+        m_activeConnection.clear();
+        m_activeAddress.clear();
         m_activeClient.clear();
         cancel();
     }
@@ -146,30 +157,32 @@ bool HostObject::authorizeConnection(const QDBusConnection &connection)
     return true;
 }
 
-bool HostObject::isActiveClient(const QString &connection, const QString &client) const
+bool HostObject::isActiveClient(const QString &connection, const QString &address, const QString &client) const
 {
-    return m_activeConnection == connection && m_activeClient == client;
+    return m_activeConnection == connection && m_activeAddress == address && m_activeClient == client;
 }
 
 bool HostObject::isActiveClient(const QString &client) const
 {
-    return isActiveClient(QDBusContext::connection().name(), client);
+    return isActiveClient(QDBusContext::connection().name(), QDBusContext::message().service(), client);
 }
 
-void HostObject::setActiveClient(const QString &connection, const QString &client)
+void HostObject::setActiveClient(const QString &connection, const QString &address, const QString &client)
 {
     m_activeConnection = connection;
+    m_activeAddress = address;
     m_activeClient = client;
 }
 
 void HostObject::setActiveClient(const QString &client)
 {
-    setActiveClient(QDBusContext::connection().name(), client);
+    setActiveClient(QDBusContext::connection().name(), QDBusContext::message().service(), client);
 }
 
 void HostObject::clearActiveClient()
 {
     m_activeConnection.clear();
+    m_activeAddress.clear();
     m_activeClient.clear();
 }
 

--- a/src/nemo-devicelock/host/hostservice.cpp
+++ b/src/nemo-devicelock/host/hostservice.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2016 Jolla Ltd
- * Contact: Andrew den Exter <andrew.den.exter@jolla.com>
+ * Copyright (c) 2016 - 2021 Jolla Ltd
+ * Copyright (c) 2021 Open Mobile Platform LLC
  *
  * You may use this file under the terms of the BSD license as follows:
  *
@@ -89,6 +89,14 @@ HostService::HostService(const QVector<HostObject *> objects, QObject *parent)
 
     qDBusRegisterMetaType<NemoDeviceLock::Fingerprint>();
     qDBusRegisterMetaType<QVector<NemoDeviceLock::Fingerprint>>();
+
+    systemBus().connectToSignal(
+                QStringLiteral("org.freedesktop.DBus"),
+                QStringLiteral("/org/freedesktop/DBus"),
+                QStringLiteral("org.freedesktop.DBus"),
+                QStringLiteral("NameLost"),
+                this,
+                SLOT(nameLost(QString)));
 
     if (!QDBusConnection::systemBus().registerService(QStringLiteral("org.nemomobile.devicelock"))) {
         qCWarning(daemon, "Failed to register service org.nemomobile.devicelock. %s",
@@ -182,6 +190,13 @@ QString HostService::socketAddress()
         return QStringLiteral("systemd:");
 
     return QStringLiteral("unix:path=/run/nemo-devicelock/socket");
+}
+
+void HostService::nameLost(const QString &name)
+{
+    for (const auto object : m_objects) {
+        object->nameLost(name);
+    }
 }
 
 }

--- a/src/nemo-devicelock/host/hostservice.h
+++ b/src/nemo-devicelock/host/hostservice.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2016 Jolla Ltd
- * Contact: Andrew den Exter <andrew.den.exter@jolla.com>
+ * Copyright (c) 2016 - 2021 Jolla Ltd
+ * Copyright (c) 2021 Open Mobile Platform LLC
  *
  * You may use this file under the terms of the BSD license as follows:
  *
@@ -70,6 +70,7 @@ private:
 
     void connectionReady(const QDBusConnection &connection);
     static QString socketAddress();
+    void nameLost(const QString &name);
 
     const QVector<HostObject *> m_objects;
 };

--- a/systemd/org.nemomobile.devicelock.conf
+++ b/systemd/org.nemomobile.devicelock.conf
@@ -2,8 +2,10 @@
 <busconfig>
   <policy user="root">
     <allow own="org.nemomobile.devicelock" />
+    <allow send_interface="org.nemomobile.devicelock.client.Authenticator"/>
   </policy>
   <policy context="default">
     <allow send_destination="org.nemomobile.devicelock" />
+    <allow receive_interface="org.nemomobile.devicelock.client.Authenticator"/>
   </policy>
 </busconfig>


### PR DESCRIPTION

Allow applications which can't connect to the device lock socket to request an authentication prompt.