### PR TITLE
[devicelock] Add support for "manual-only" locking setting. JB#47849

### DIFF
--- a/src/nemo-devicelock/host/mcedevicelock.cpp
+++ b/src/nemo-devicelock/host/mcedevicelock.cpp
@@ -254,6 +254,10 @@ bool MceDeviceLock::needLockTimer()
     if (automaticLocking() <= 0)
         return false;
 
+    /* Must not be in manual-only mode */
+    if (automaticLocking() >= 254)
+        return false;
+
     /* Must not have active call */
     if (m_callActive)
         return false;


### PR DESCRIPTION
Value 254 for automaticLocking is reserved for "manual locking only".

Do not start locking timer when it is used.