### PR TITLE
Protect against bad lock code lengths when setting new

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 Makefile
+Makefile.*
 *.o
 *.so*
+*.a
 moc_*
+*.moc
 *.pc
 *.prl

--- a/rpm/nemo-qml-plugin-devicelock.spec
+++ b/rpm/nemo-qml-plugin-devicelock.spec
@@ -1,9 +1,9 @@
 Name:       nemo-qml-plugin-devicelock
 Summary:    Device lock plugin for Nemo Mobile
-Version:    0.2.22
+Version:    0.4.1
 Release:    1
 License:    BSD and LGPLv2
-URL:        https://git.sailfishos.org/mer-core/nemo-qml-plugin-devicelock
+URL:        https://github.com/sailfishos/nemo-qml-plugin-devicelock/
 Source0:    %{name}-%{version}.tar.bz2
 BuildRequires:  pkgconfig(Qt5DBus)
 BuildRequires:  pkgconfig(Qt5Core)
@@ -51,10 +51,9 @@ Requires:   pkgconfig(nemodbus)
 
 %build
 %qmake5 "VERSION=%{version}"
-make %{?_smp_mflags}
+%make_build
 
 %install
-rm -rf %{buildroot}
 %qmake5_install
 
 mkdir -p %{buildroot}%{_unitdir}/multi-user.target.wants
@@ -65,7 +64,6 @@ ln -sf ../nemo-devicelock.socket %{buildroot}%{_unitdir}/multi-user.target.wants
 %postun -p /sbin/ldconfig
 
 %files
-%defattr(-,root,root,-)
 %{_libdir}/libnemodevicelock.so.*
 %dir %{_libdir}/qt5/qml/org/nemomobile/devicelock
 %{_libdir}/qt5/qml/org/nemomobile/devicelock/libnemodevicelockplugin.so
@@ -77,12 +75,10 @@ ln -sf ../nemo-devicelock.socket %{buildroot}%{_unitdir}/multi-user.target.wants
 %license LICENSE.LGPL
 
 %files -n nemo-devicelock-daemon-cli
-%defattr(-,root,root,-)
 %{_libexecdir}/nemo-devicelock
 %{_unitdir}/nemo-devicelock.service
 
 %files devel
-%defattr(-,root,root,-)
 %dir %{_includedir}/nemo-devicelock
 %{_includedir}/nemo-devicelock/*.h
 %{_includedir}/nemo-devicelock/private/*.h
@@ -91,7 +87,6 @@ ln -sf ../nemo-devicelock.socket %{buildroot}%{_unitdir}/multi-user.target.wants
 %{_libdir}/pkgconfig/nemodevicelock.pc
 
 %files host-devel
-%defattr(-,root,root,-)
 %dir %{_includedir}/nemo-devicelock/host
 %{_includedir}/nemo-devicelock/host/*.h
 %{_libdir}/libnemodevicelock-host.a

--- a/src/daemon/daemon.pro
+++ b/src/daemon/daemon.pro
@@ -5,7 +5,6 @@ QT -= gui
 QT += dbus
 
 CONFIG += \
-        c++11 \
         link_pkgconfig
 
 PKGCONFIG += \

--- a/src/nemo-devicelock/authenticationinput.cpp
+++ b/src/nemo-devicelock/authenticationinput.cpp
@@ -419,7 +419,6 @@ void AuthenticationInput::setRegistered(bool registered)
 /*!
     Sends an entered security \a code to the security daemon to be verified.
 */
-
 void AuthenticationInput::enterSecurityCode(const QString &code)
 {
     call(QStringLiteral("EnterSecurityCode"), m_localPath, code);
@@ -428,7 +427,6 @@ void AuthenticationInput::enterSecurityCode(const QString &code)
 /*!
     Sends a request for the security daemon to suggest a new security code.
 */
-
 void AuthenticationInput::requestSecurityCode()
 {
     call(QStringLiteral("RequestSecurityCode"), m_localPath);
@@ -437,7 +435,6 @@ void AuthenticationInput::requestSecurityCode()
 /*!
     Informs the security dialog that an action was authorized without authenticating.
 */
-
 void AuthenticationInput::authorize()
 {
     call(QStringLiteral("Authorize"), m_localPath);
@@ -446,7 +443,6 @@ void AuthenticationInput::authorize()
 /*!
     Sends a request to cancel authentication to the security daemon.
 */
-
 void AuthenticationInput::cancel()
 {
     if (m_status != Idle) {
@@ -530,7 +526,6 @@ void AuthenticationInput::handleAuthenticationUnavailable(int pid, Error error)
         emit statusChanged();
     }
 }
-
 
 void AuthenticationInput::handleAuthenticationResumed(
         Authenticator::Methods utilizedMethods, Feedback feedback, const QVariantMap &data)

--- a/src/nemo-devicelock/authenticationinput.h
+++ b/src/nemo-devicelock/authenticationinput.h
@@ -97,7 +97,9 @@ public:
         PermanentlyLocked,
         UnlockToPerformOperation,
         SecurityCodeRequiredAfterReboot,
-        UnrecognizedFingerLimitExceeded
+        UnrecognizedFingerLimitExceeded,
+        NewSecurityCodeTooShort,
+        NewSecurityCodeTooLong
     };
     Q_ENUM(Feedback)
 

--- a/src/nemo-devicelock/authenticator.cpp
+++ b/src/nemo-devicelock/authenticator.cpp
@@ -72,7 +72,6 @@ void AuthenticatorAdaptor::Aborted()
 /*!
     Constructs a new authenticator which is a child of \a parent.
 */
-
 Authenticator::Authenticator(QObject *parent)
     : QObject(parent)
     , ConnectionClient(
@@ -100,7 +99,6 @@ Authenticator::Authenticator(QObject *parent)
 /*!
     Destroys an authenticator.
 */
-
 Authenticator::~Authenticator()
 {
 }
@@ -110,7 +108,6 @@ Authenticator::~Authenticator()
 
     This property holds the authentication methods that may currently be utilized.
 */
-
 Authenticator::Methods Authenticator::availableMethods() const
 {
     return m_availableMethods;
@@ -121,7 +118,6 @@ Authenticator::Methods Authenticator::availableMethods() const
 
     This property holds whether the the authenticator is currently authenticating a challenge code.
 */
-
 bool Authenticator::isAuthenticating() const
 {
     return m_authenticating;
@@ -130,7 +126,6 @@ bool Authenticator::isAuthenticating() const
 /*!
     Requests the authentication of a \a challengeCode using any of the supplied \a methods.
 */
-
 void Authenticator::authenticate(const QVariant &challengeCode, Methods methods)
 {
     const auto response = call(QStringLiteral("Authenticate"), m_localPath, challengeCode, uint(methods));
@@ -162,7 +157,6 @@ void Authenticator::authenticate(const QVariant &challengeCode, Methods methods)
     \li The PID of the application permissions are being requested for.
     \endtable
 */
-
 void Authenticator::requestPermission(
         const QString &message, const QVariantMap &properties, Methods methods)
 {
@@ -184,7 +178,6 @@ void Authenticator::requestPermission(
 /*!
     Cancels an active authentication request.
 */
-
 void Authenticator::cancel()
 {
     if (m_authenticating) {

--- a/src/nemo-devicelock/authorization.cpp
+++ b/src/nemo-devicelock/authorization.cpp
@@ -48,7 +48,6 @@ namespace NemoDeviceLock
 /*!
     Constructs an authorization instance which is a child of \a parent.
 */
-
 Authorization::Authorization(QObject *parent)
     : QObject(parent)
 {
@@ -57,7 +56,6 @@ Authorization::Authorization(QObject *parent)
 /*!
     Destroys an authorization instance.
 */
-
 Authorization::~Authorization()
 {
 }

--- a/src/nemo-devicelock/devicelock.cpp
+++ b/src/nemo-devicelock/devicelock.cpp
@@ -198,7 +198,6 @@ void DeviceLock::unlock()
 /*!
     Cancels a request for user authentication to unlock the device.
 */
-
 void DeviceLock::cancel()
 {
     if (m_unlocking) {

--- a/src/nemo-devicelock/devicereset.cpp
+++ b/src/nemo-devicelock/devicereset.cpp
@@ -88,7 +88,6 @@ DeviceReset::~DeviceReset()
     \property NemoDeviceLock::DeviceReset::authorization
 
     This property provides a means of acquiring authorization to reset the device.
-
 */
 
 Authorization *DeviceReset::authorization()

--- a/src/nemo-devicelock/encryptionsettings.cpp
+++ b/src/nemo-devicelock/encryptionsettings.cpp
@@ -44,7 +44,6 @@ namespace NemoDeviceLock
 /*!
     Constructs a new instance of the encryption settings interface which is a child of \a parent.
 */
-
 EncryptionSettings::EncryptionSettings(QObject *parent)
     : QObject(parent)
     , ConnectionClient(
@@ -68,7 +67,6 @@ EncryptionSettings::EncryptionSettings(QObject *parent)
 /*!
     Destroys an encryption settings instance.
 */
-
 EncryptionSettings::~EncryptionSettings()
 {
 }

--- a/src/nemo-devicelock/fingerprintsensor.cpp
+++ b/src/nemo-devicelock/fingerprintsensor.cpp
@@ -81,7 +81,6 @@ namespace NemoDeviceLock
 /*!
     Constructs a new fingerprint model which is a child of \a parent.
 */
-
 FingerprintModel::FingerprintModel(QObject *parent)
     : QAbstractListModel(parent)
     , ConnectionClient(
@@ -103,7 +102,6 @@ FingerprintModel::FingerprintModel(QObject *parent)
 /*!
     Destroys a fingerprint model.
 */
-
 FingerprintModel::~FingerprintModel()
 {
 }
@@ -125,7 +123,6 @@ Authorization *FingerprintModel::authorization()
     The fingerprint authorization challenge code must be authenticated before this is called and the
     \a authenticationToken produced passed as an argument.
 */
-
 void FingerprintModel::remove(const QVariant &authenticationToken, const QVariant &id)
 {
     if (m_authorization.status() == Authorization::ChallengeIssued) {
@@ -136,7 +133,6 @@ void FingerprintModel::remove(const QVariant &authenticationToken, const QVarian
 /*!
     Changes the user friendly name of the fingerprint \a id to \a name.
 */
-
 void FingerprintModel::rename(const QVariant &id, const QString &name)
 {
     if (m_authorization.status() == Authorization::ChallengeIssued) {
@@ -263,7 +259,6 @@ void FingerprintSensorAdaptor::AcquisitionError(uint error)
 /*!
     Constructs a new instance of the fingerprint sensor interface which is a child of \a parent.
 */
-
 FingerprintSensor::FingerprintSensor(QObject *parent)
     : QObject(parent)
     , ConnectionClient(
@@ -300,7 +295,6 @@ FingerprintSensor::FingerprintSensor(QObject *parent)
 /*!
     Destroys an instance of the fingerprint sensor interface.
 */
-
 FingerprintSensor::~FingerprintSensor()
 {
 }
@@ -372,7 +366,6 @@ int FingerprintSensor::samplesRequired() const
     The sensor authorization challenge code must be authenticated before this is called and the
     \a authenticationToken produced passed as an argument.
 */
-
 void FingerprintSensor::acquireFinger(const QVariant &authenticationToken)
 {
     if (m_authorization.status() == Authorization::ChallengeIssued) {
@@ -402,7 +395,6 @@ void FingerprintSensor::acquireFinger(const QVariant &authenticationToken)
 /*!
     Cancels an ongoing fingerprint acquisition.
 */
-
 void FingerprintSensor::cancelAcquisition()
 {
     if (m_isAcquiring) {

--- a/src/nemo-devicelock/host/host.pro
+++ b/src/nemo-devicelock/host/host.pro
@@ -3,7 +3,6 @@ TARGET  = nemodevicelock-host
 
 CONFIG += \
         static \
-        c++11 \
         link_pkgconfig
 
 QT -= gui

--- a/src/nemo-devicelock/host/hostauthenticationinput.cpp
+++ b/src/nemo-devicelock/host/hostauthenticationinput.cpp
@@ -321,6 +321,16 @@ int HostAuthenticationInput::currentAttempts() const
     return m_settings->currentAttempts;
 }
 
+int HostAuthenticationInput::minimumCodeLength() const
+{
+    return m_settings->minimumLength;
+}
+
+int HostAuthenticationInput::maximumCodeLength() const
+{
+    return m_settings->maximumLength;
+}
+
 AuthenticationInput::CodeGeneration HostAuthenticationInput::codeGeneration() const
 {
     return m_settings->codeGeneration;

--- a/src/nemo-devicelock/host/hostauthenticationinput.h
+++ b/src/nemo-devicelock/host/hostauthenticationinput.h
@@ -106,6 +106,9 @@ public:
     virtual int maximumAttempts() const;
     virtual int currentAttempts() const;
 
+    virtual int minimumCodeLength() const;
+    virtual int maximumCodeLength() const;
+
     virtual AuthenticationInput::CodeGeneration codeGeneration() const;
     virtual QString generateCode() const;
 

--- a/src/nemo-devicelock/host/hostauthenticator.cpp
+++ b/src/nemo-devicelock/host/hostauthenticator.cpp
@@ -308,15 +308,18 @@ void HostAuthenticator::beginChangeSecurityCode(uint pid, const QVariant &challe
         // because we need to pass the extra pid argument to startAuthentication().
         if (codeGeneration() == AuthenticationInput::MandatoryCodeGeneration) {
             m_state = ExpectingGeneratedSecurityCode;
-            startAuthentication(AuthenticationInput::SuggestSecurityCode, pid, generatedCodeData(), Authenticator::SecurityCode);
+            startAuthentication(AuthenticationInput::SuggestSecurityCode, pid, generatedCodeData(),
+                                Authenticator::SecurityCode);
         } else {
             m_state = EnteringNewSecurityCode;
-            startAuthentication(AuthenticationInput::EnterNewSecurityCode, pid, QVariantMap(), Authenticator::SecurityCode);
+            startAuthentication(AuthenticationInput::EnterNewSecurityCode, pid, QVariantMap(),
+                                Authenticator::SecurityCode);
         }
         break;
     case CanAuthenticateSecurityCode:
     case CanAuthenticate:
-        startAuthentication(AuthenticationInput::EnterSecurityCode, pid, QVariantMap(), Authenticator::SecurityCode);
+        startAuthentication(AuthenticationInput::EnterSecurityCode, pid, QVariantMap(),
+                            Authenticator::SecurityCode);
         break;
     case CodeEntryLockedRecoverable:
     case CodeEntryLockedPermanent:
@@ -498,7 +501,9 @@ void HostAuthenticator::checkCodeFinished(int result)
 {
     const FeedbackFunction feebackFunction = (m_state & EvaluatingFlag)
         ? &HostAuthenticationInput::authenticationResumed
-        : static_cast<void (HostAuthenticationInput::*)(AuthenticationInput::Feedback, const QVariantMap &, Authenticator::Methods)>(&HostAuthenticationInput::feedback);
+        : static_cast<void (HostAuthenticationInput::*)(AuthenticationInput::Feedback,
+                                                        const QVariantMap &,
+                                                        Authenticator::Methods)>(&HostAuthenticationInput::feedback);
 
     m_state = State(m_state & ~EvaluatingFlag);
 
@@ -641,7 +646,8 @@ void HostAuthenticator::confirmAuthentication(Authenticator::Method method)
         authenticated(authenticateChallengeCode(m_challengeCode, method, m_authenticatingPid));
         break;
     case AuthenticationEvaluating:
-        sendToActiveClient(authenticatorInterface, QStringLiteral("Authenticated"), authenticateChallengeCode(m_challengeCode, method, m_authenticatingPid));
+        sendToActiveClient(authenticatorInterface, QStringLiteral("Authenticated"),
+                           authenticateChallengeCode(m_challengeCode, method, m_authenticatingPid));
         m_state = AuthenticationCompleted;
         authenticationInactive();
         break;

--- a/src/nemo-devicelock/host/hostauthenticator.cpp
+++ b/src/nemo-devicelock/host/hostauthenticator.cpp
@@ -408,10 +408,16 @@ void HostAuthenticator::enterSecurityCode(const QString &code)
     }
     case EnteringNewSecurityCode:
         qCDebug(daemon, "New security code entered.");
-        m_newCode = code;
-        m_state = RepeatingNewSecurityCode;
-        m_repeatsRequired = 1;
-        feedback(AuthenticationInput::RepeatNewSecurityCode, -1);
+        if (code.length() < minimumCodeLength()) {
+            feedback(AuthenticationInput::NewSecurityCodeTooShort, -1);
+        } else if (code.length() > maximumCodeLength()) {
+            feedback(AuthenticationInput::NewSecurityCodeTooLong, -1);
+        } else {
+            m_newCode = code;
+            m_state = RepeatingNewSecurityCode;
+            m_repeatsRequired = 1;
+            feedback(AuthenticationInput::RepeatNewSecurityCode, -1);
+        }
         return;
     case ExpectingGeneratedSecurityCode:
         if (m_generatedCode == code) {

--- a/src/nemo-devicelock/host/hostdevicelock.cpp
+++ b/src/nemo-devicelock/host/hostdevicelock.cpp
@@ -148,7 +148,8 @@ void HostDeviceLock::enterSecurityCode(const QString &code)
     case Idle:
         break;
     case Authenticating: {
-        switch (const int result = unlockWithCode(code)) {
+        const int result = unlockWithCode(code);
+        switch (result) {
         case SecurityCodeExpired:
             m_state = EnteringNewSecurityCode;
             m_currentCode = code;
@@ -278,7 +279,8 @@ void HostDeviceLock::unlockFinished(int result, Authenticator::Method method)
 
         if (m_state == Unlocking) {
             m_state = Authenticating;
-            authenticationResumed(AuthenticationInput::IncorrectSecurityCode, {{ QStringLiteral("attemptsRemaining"), attemptsRemaining }});
+            authenticationResumed(AuthenticationInput::IncorrectSecurityCode,
+                                  {{ QStringLiteral("attemptsRemaining"), attemptsRemaining }});
         } else {
             feedback(AuthenticationInput::IncorrectSecurityCode, attemptsRemaining);
         }

--- a/src/nemo-devicelock/host/nemo-devicelock-host.prf
+++ b/src/nemo-devicelock/host/nemo-devicelock-host.prf
@@ -2,7 +2,6 @@
 QT *= dbus
 
 CONFIG *= \
-        c++11 \
         link_pkgconfig
 
 PKGCONFIG += \

--- a/src/nemo-devicelock/lib.pro
+++ b/src/nemo-devicelock/lib.pro
@@ -2,7 +2,6 @@ TEMPLATE = lib
 TARGET  = nemodevicelock
 
 CONFIG += \
-        c++11 \
         hide_symbols \
         link_pkgconfig \
         create_pc \

--- a/src/nemo-devicelock/private/settingswatcher.cpp
+++ b/src/nemo-devicelock/private/settingswatcher.cpp
@@ -268,11 +268,15 @@ void SettingsWatcher::reloadSettings()
     read(settings, this, currentIsDigitOnlyKey, true, &currentCodeIsDigitOnly, &SettingsWatcher::currentCodeIsDigitOnlyChanged);
     read(settings, this, isHomeEncryptedKey, false, &isHomeEncrypted);
 
-    read(settings, this, "maximum_automatic_locking", -1, &maximumAutomaticLocking, &SettingsWatcher::maximumAutomaticLockingChanged);
-    read(settings, this, "absolute_maximum_attempts", -1, &absoluteMaximumAttempts, &SettingsWatcher::absoluteMaximumAttemptsChanged);
-    read(settings, this, "supported_device_reset_options", DeviceReset::Options(DeviceReset::Reboot), &supportedDeviceResetOptions, &SettingsWatcher::supportedDeviceResetOptionsChanged);
+    read(settings, this, "maximum_automatic_locking", -1, &maximumAutomaticLocking,
+         &SettingsWatcher::maximumAutomaticLockingChanged);
+    read(settings, this, "absolute_maximum_attempts", -1, &absoluteMaximumAttempts,
+         &SettingsWatcher::absoluteMaximumAttemptsChanged);
+    read(settings, this, "supported_device_reset_options", DeviceReset::Options(DeviceReset::Reboot),
+         &supportedDeviceResetOptions, &SettingsWatcher::supportedDeviceResetOptionsChanged);
     read(settings, this, "code_is_mandatory", false, &codeIsMandatory, &SettingsWatcher::codeIsMandatoryChanged);
-    read(settings, this, "code_generation", AuthenticationInput::NoCodeGeneration, &codeGeneration, &SettingsWatcher::codeGenerationChanged);
+    read(settings, this, "code_generation", AuthenticationInput::NoCodeGeneration,
+         &codeGeneration, &SettingsWatcher::codeGenerationChanged);
 
     g_key_file_free(settings);
 }

--- a/src/nemo-devicelock/securitycodesettings.cpp
+++ b/src/nemo-devicelock/securitycodesettings.cpp
@@ -70,7 +70,6 @@ void SecurityCodeSettingsAdaptor::ClearAborted()
 /*!
     Constructs a new security code settings interface which is a child of \a parent.
 */
-
 SecurityCodeSettings::SecurityCodeSettings(QObject *parent)
     : QObject(parent)
     , ConnectionClient(
@@ -103,7 +102,6 @@ SecurityCodeSettings::SecurityCodeSettings(QObject *parent)
 /*!
     Destroys a security code settings interface.
 */
-
 SecurityCodeSettings::~SecurityCodeSettings()
 {
 }
@@ -133,7 +131,6 @@ bool SecurityCodeSettings::isMandatory() const
     to enter a new security code and then edit their security settings or also add a fingerprint
     without being prompted for the new code immediately.
 */
-
 void SecurityCodeSettings::change(const QVariant &challengeCode)
 {
     if (m_changing) {
@@ -192,7 +189,6 @@ void SecurityCodeSettings::handleChangeAborted()
     The security daemon will display a prompt asking the user to authenticate themselves before
     proceeding with clearing the security code.
 */
-
 void SecurityCodeSettings::clear()
 {
     if (m_changing) {
@@ -213,7 +209,6 @@ void SecurityCodeSettings::clear()
 /*!
     Cancels an ongoing attempt to change or clear the user's security code.
 */
-
 void SecurityCodeSettings::cancel()
 {
     if (m_changing) {

--- a/src/plugin/plugin.pro
+++ b/src/plugin/plugin.pro
@@ -10,7 +10,6 @@ QT += dbus qml
 CONFIG += \
         plugin \
         hide_symbols \
-        c++11 \
         link_pkgconfig
 
 INCLUDEPATH += \


### PR DESCRIPTION
Better not trust the UI too much that it provides only proper sized lock codes. Adding here extra checks and signalling for error cases.

Some clean ups while at it, all in separate commits.