### PR TITLE
[devicelock] Add activateTemporaryLockout D-Bus method handler. JB#63484

### DIFF
--- a/src/nemo-devicelock/host/hostauthenticationinput.cpp
+++ b/src/nemo-devicelock/host/hostauthenticationinput.cpp
@@ -321,6 +321,11 @@ int HostAuthenticationInput::currentAttempts() const
     return m_settings->currentAttempts;
 }
 
+qint64 HostAuthenticationInput::temporaryLockTimeout() const
+{
+    return m_settings->temporaryLockTimeout;
+}
+
 int HostAuthenticationInput::minimumCodeLength() const
 {
     return m_settings->minimumLength;

--- a/src/nemo-devicelock/host/hostauthenticationinput.h
+++ b/src/nemo-devicelock/host/hostauthenticationinput.h
@@ -105,6 +105,7 @@ public:
 
     virtual int maximumAttempts() const;
     virtual int currentAttempts() const;
+    virtual qint64 temporaryLockTimeout() const;
 
     virtual int minimumCodeLength() const;
     virtual int maximumCodeLength() const;

--- a/src/nemo-devicelock/host/mcedevicelock.h
+++ b/src/nemo-devicelock/host/mcedevicelock.h
@@ -59,6 +59,8 @@ class MceDeviceLockAdaptor : public QDBusAbstractAdaptor
 "    <method name=\"setState\">\n"
 "      <arg direction=\"in\" type=\"i\" name=\"state\"/>\n"
 "    </method>\n"
+"    <method name=\"activateTemporaryLockout\">\n"
+"    </method>\n"
 "    <signal name=\"stateChanged\">\n"
 "      <arg type=\"i\" name=\"state\"/>\n"
 "    </signal>\n"
@@ -70,7 +72,7 @@ public:
 public slots:
     int state();
     void setState(int state);
-
+    void activateTemporaryLockout();
 signals:
     void stateChanged(int state);
 
@@ -101,6 +103,9 @@ protected slots:
     void handleDisplayStateChanged(const QString &state);
     void handleInactivityStateChanged(const bool state);
     void handleLpmModeChanged(const QString &state);
+
+signals:
+    void temporaryLockoutRequest();
 
 private:
     void trackMceProperty(


### PR DESCRIPTION
Sanity check that device lock settings and client privileges allow activating temporary lockout. Component that handles actual activation needs to subscribe to temporaryLockoutRequest() signals.