### PR TITLE
[devicelock] Signal authentication check results on D-Bus. JB#63488

### DIFF
--- a/src/nemo-devicelock/host/mcedevicelock.cpp
+++ b/src/nemo-devicelock/host/mcedevicelock.cpp
@@ -350,6 +350,11 @@ void MceDeviceLock::stateChanged()
     emit m_adaptor.stateChanged(state());
 }
 
+void MceDeviceLock::authenticationChecked(bool success)
+{
+    emit m_adaptor.authenticationChecked(success);
+}
+
 void MceDeviceLock::automaticLockingChanged()
 {
     setStateAndSetupLockTimer();

--- a/src/nemo-devicelock/host/mcedevicelock.h
+++ b/src/nemo-devicelock/host/mcedevicelock.h
@@ -64,6 +64,9 @@ class MceDeviceLockAdaptor : public QDBusAbstractAdaptor
 "    <signal name=\"stateChanged\">\n"
 "      <arg type=\"i\" name=\"state\"/>\n"
 "    </signal>\n"
+"    <signal name=\"authenticationChecked\">\n"
+"      <arg type=\"b\" name=\"success\"/>\n"
+"    </signal>\n"
 "  </interface>\n"
         "")
 public:
@@ -75,6 +78,7 @@ public slots:
     void activateTemporaryLockout();
 signals:
     void stateChanged(int state);
+    void authenticationChecked(bool success);
 
 private:
     MceDeviceLock * const m_deviceLock;
@@ -103,6 +107,9 @@ protected slots:
     void handleDisplayStateChanged(const QString &state);
     void handleInactivityStateChanged(const bool state);
     void handleLpmModeChanged(const QString &state);
+
+public slots:
+    void authenticationChecked(bool success);
 
 signals:
     void temporaryLockoutRequest();


### PR DESCRIPTION
Enabler for external lockout policy enforcement.

Authenticating component needs to emit signals to the slot provided here.